### PR TITLE
Catch LND error response in payInvoice

### DIFF
--- a/src/backends/lnd-rest/lnd-rest.ts
+++ b/src/backends/lnd-rest/lnd-rest.ts
@@ -57,6 +57,8 @@ export default class LndRest extends Backend {
     const body = this.prepareBody(data)
     const options = this.getRequestOptions(EHttpVerb.POST, '/v1/channels/transactions')
     const response = await this.request(options, body) as IPaymentSent
+    
+    if (response.code) throw new Error(`${response.message} (Code ${response.code})`)
 
     const result: IInvoicePaid = {
       paymentPreimage: base64ToHex(response.payment_preimage),


### PR DESCRIPTION
If there's an error paying an invoice, the code will fail on base64ToHex as there's no payment_preimage. This bubbles up the error code and message.